### PR TITLE
Removed null argument passed to callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 function nodify (promise, callback) {
   promise
-    .then((...args) => { callback(null, ...args) })
+    .then((...args) => { callback(...args) })
     .catch((err) => { callback(err) })
 }
 


### PR DESCRIPTION
I removed the unnecessary null argument that the nodify function passes to the callback.